### PR TITLE
fix: 著者ページ、アバターへのリンクが切れる

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -45,7 +45,12 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addFilter("dateToRfc3339", pluginRSS.dateToRfc3339);
 
     eleventyConfig.addFilter("getAuthorLink", (id) => {
-        let path = "/author/" + eleventyConfig.getFilter("slugify")(id);
+        let path = `/author/${id}`;
+        return eleventyConfig.getFilter("url")(path);
+    });
+
+    eleventyConfig.addFilter("getAuthorAvatarLink", (id) => {
+        let path = `/assets/img/avatars/${id}.png`;
         return eleventyConfig.getFilter("url")(path);
     });
 

--- a/src/_includes/article.njk
+++ b/src/_includes/article.njk
@@ -26,7 +26,7 @@
                 <div class="post-meta">
                     <time datetime="{{ date.toISOString() }}" itemprop="dateModified">{{ date | readableDate }}</time>
                     <div class="post-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
-                        <img src='{{ "/assets/img/avatars/" + author + ".png" | url }}' height="24" itemprop="image" />
+                        <img src='{{ author  | getAuthorAvatarLink }}' height="24" itemprop="image" />
                         <a href='{{ author | getAuthorLink }}' itemprop="name">{{authors[author].name}}</a>
                     </div>
                     <ul class="post-tags">

--- a/src/author.njk
+++ b/src/author.njk
@@ -12,7 +12,7 @@ eleventyComputed:
 
 <article itemscope itemtype="https://schema.org/Person">
     <h1 itemprop="name">{{ authors[author]["name"] }}</h1>
-    <img src='{{ ("/assets/img/avatars/" + authors[author].id + ".png") | url }}' alt="" width="180" itemprop="image">
+    <img src="{{ authors[author].id | getAuthorAvatarLink }}" alt="" width="180" itemprop="image">
     <p itemprop="description">{{ authors[author]["description"] }}</p>
     <ul>
         {% for link in authors[author].links %}


### PR DESCRIPTION
- slugifyを使うことでアンダーバーがハイフンになってしまう問題の修正